### PR TITLE
Set node version for vercel and etc.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
     "dev": "next",
     "build": "next build"
   },
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "dependencies": {
     "@tailwindcss/typography": "^0.3.1",
     "autoprefixer": "^10.0.4",


### PR DESCRIPTION
The changes in the previous PR for UI updates requires Node to be >= 12.0.0 and to notify Vercel and maybe other platforms to use this version, these changes were added.